### PR TITLE
Fixes #63.  Full discovery and analysis API working with nRF52832 now

### DIFF
--- a/config/zephyr/nRF52832.conf
+++ b/config/zephyr/nRF52832.conf
@@ -1,22 +1,23 @@
 
 #CONFIG_NORDIC_SECURITY_BACKEND=y
-# CONFIG_NRF_SECURITY_RNG=y
+#CONFIG_NRF_SECURITY_RNG=y
 CONFIG_ENTROPY_GENERATOR=y
 
-# Simple Payload support BEGINS
-# Option 1: MBEDTLS
+#Simple Payload support BEGINS
+#Option 1: MBEDTLS
 #CONFIG_MBEDTLS_VANILLA_BACKEND=y
 #CONFIG_MBEDTLS_MAC_SHA256_ENABLED=y
 #CONFIG_MBEDTLS=y
 #CONFIG_MBEDTLS_BUILTIN=y
 #CONFIG_MBEDTLS_CFG_FILE="config-tls-generic.h"
 
-# Option 2: TINYCRYPT
+#Option 2: TINYCRYPT
 CONFIG_TINYCRYPT_SHA256=y
-# Simple Payload Support ENDS
+#Simple Payload Support ENDS
 
 #CONFIG_BT_MAX_CONN=20
 CONFIG_BT_MAX_CONN=2
 
-# Fix for use of heap in gatt_gm erroring with undefined reference to k_aligned_alloc
-CONFIG_HEAP_MEM_POOL_SIZE=256
+#Fix for use of heap in gatt_gm erroring with undefined reference to k_aligned_alloc
+CONFIG_HEAP_MEM_POOL_SIZE=512
+#The more memory reserved for zephyr, the less available for newlibc - so don't set this any higher than needed!

--- a/config/zephyr/nRF52833.conf
+++ b/config/zephyr/nRF52833.conf
@@ -19,4 +19,5 @@ CONFIG_TINYCRYPT_SHA256=y
 CONFIG_BT_MAX_CONN=10
 
 # Fix for use of heap in gatt_gm erroring with undefined reference to k_aligned_alloc
-CONFIG_HEAP_MEM_POOL_SIZE=256
+CONFIG_HEAP_MEM_POOL_SIZE=1024
+#The more memory reserved for zephyr, the less available for newlibc - so don't set this any higher than needed!

--- a/config/zephyr/nRF52840.conf
+++ b/config/zephyr/nRF52840.conf
@@ -23,4 +23,5 @@ CONFIG_TINYCRYPT_SHA256=y
 CONFIG_BT_MAX_CONN=10
 
 # Fix for use of heap in gatt_gm erroring with undefined reference to k_aligned_alloc
-CONFIG_HEAP_MEM_POOL_SIZE=256
+CONFIG_HEAP_MEM_POOL_SIZE=1024
+#The more memory reserved for zephyr, the less available for newlibc - so don't set this any higher than needed!

--- a/config/zephyr/nRF5340.conf
+++ b/config/zephyr/nRF5340.conf
@@ -4,7 +4,7 @@
 #CONFIG_NRF_CC3XX_PLATFORM=y
 #CONFIG_CC3XX_BACKEND=y
 #CONFIG_NORDIC_SECURITY_BACKEND=y
-CONFIG_NRF_SECURITY_RNG=y
+#CONFIG_NRF_SECURITY_RNG=y
 CONFIG_ENTROPY_GENERATOR=y
 
 # Simple Payload support BEGINS
@@ -26,4 +26,5 @@ CONFIG_BT_MAX_CONN=10
 
 # Fix for use of heap in gatt_gm erroring with undefined reference to k_aligned_alloc
 CONFIG_HEAP_MEM_POOL_SIZE=1024
-# 5340 has lots of RAM, so use it
+#5340 has lots of RAM, so use it
+#The more memory reserved for zephyr, the less available for newlibc - so don't set this any higher than needed!


### PR DESCRIPTION
Known limitations:-
- SimplePayload uses too much memory for nRF52832. Need to revise its design.
- Using FixedPayload (same ID per device) right now (removed hwinfo API due to memory use)
Signed-off-by: Adam Fowler <adam@adamfowler.org>
