### PR TITLE
Fixes #69. Pre-emptively removing old devices on duplicate payload

### DIFF
--- a/herald-tests/bledatabase-tests.cpp
+++ b/herald-tests/bledatabase-tests.cpp
@@ -97,3 +97,117 @@ TEST_CASE("ble-database-callback-verify", "[ble][database][callback][verify]") {
 
   }
 }
+
+
+
+TEST_CASE("ble-database-macrotate-samepayload", "[ble][database][macrotate][samepayload]") {
+  SECTION("ble-callback-macrotate-samepayload") {
+    DummyLoggingSink dls;
+    DummyBluetoothStateManager dbsm;
+    herald::DefaultPlatformType dpt;
+    herald::Context ctx(dpt,dls,dbsm); // default context include
+    using CT = typename herald::Context<herald::DefaultPlatformType,DummyLoggingSink,DummyBluetoothStateManager>;
+    herald::ble::ConcreteBLEDatabase<CT> db(ctx);
+    DummyBLEDBDelegate delegate;
+    db.add(delegate);
+
+    REQUIRE(db.size() == 0);
+    REQUIRE(delegate.createCallbackCalled == false);
+    REQUIRE(delegate.updateCallbackCalled == false);
+    REQUIRE(delegate.deleteCallbackCalled == false);
+
+    herald::datatype::Data devMac(std::byte(0x02),6);
+    herald::datatype::TargetIdentifier dev(devMac);
+
+    // add in new device
+    herald::ble::BLEDevice& devPtr = db.device(dev);
+    auto devices = db.matches([](auto& deviceRef) {
+      return true;
+    });
+    std::cout << "Devices:-" << std::endl;
+    for (auto& d : devices) {
+      std::cout << "Mac: " << d.get().identifier() 
+                << ", Payload: " << (d.get().payloadData().has_value() ? d.get().payloadData().value().hexEncodedString() : "Empty") << std::endl;
+    }
+    REQUIRE(db.size() == 1);
+    REQUIRE(delegate.createCallbackCalled == true);
+    REQUIRE(delegate.updateCallbackCalled == false);
+    REQUIRE(delegate.deleteCallbackCalled == false);
+    REQUIRE(delegate.dev.has_value());
+    REQUIRE(delegate.dev.value().get() == devPtr);
+
+    // read its payload
+    herald::data::PayloadData devPayload(std::byte(0x55),24);
+    devPtr.payloadData(devPayload);
+    devices = db.matches([](auto& deviceRef) {
+      return true;
+    });
+    std::cout << "Devices:-" << std::endl;
+    for (auto& d : devices) {
+      std::cout << "Mac: " << d.get().identifier() 
+                << ", Payload: " << (d.get().payloadData().has_value() ? d.get().payloadData().value().hexEncodedString() : "Empty") << std::endl;
+    }
+    REQUIRE(db.size() == 1);
+    REQUIRE(delegate.createCallbackCalled == true);
+    REQUIRE(delegate.updateCallbackCalled == true);
+    REQUIRE(delegate.deleteCallbackCalled == false);
+    REQUIRE(delegate.dev.has_value());
+    REQUIRE(delegate.dev.value().get() == devPtr);
+
+    // add a second device via mac
+    herald::datatype::Data dev2Mac(std::byte(0x03),6);
+    herald::datatype::TargetIdentifier dev2(dev2Mac);
+    herald::ble::BLEDevice& dev2Ptr = db.device(dev2);
+    devices = db.matches([](auto& deviceRef) {
+      return true;
+    });
+    std::cout << "Devices:-" << std::endl;
+    for (auto& d : devices) {
+      std::cout << "Mac: " << d.get().identifier() 
+                << ", Payload: " << (d.get().payloadData().has_value() ? d.get().payloadData().value().hexEncodedString() : "Empty") << std::endl;
+    }
+    REQUIRE(db.size() == 2);
+    REQUIRE(delegate.createCallbackCalled == true);
+    REQUIRE(delegate.updateCallbackCalled == true); // from first device's payload
+    REQUIRE(delegate.deleteCallbackCalled == false);
+    REQUIRE(delegate.dev.has_value());
+    REQUIRE(delegate.dev.value().get() == dev2Ptr);
+
+    // now assume the first device's mac rotates
+    herald::datatype::Data devRefreshMac(std::byte(0x08),6);
+    herald::datatype::TargetIdentifier devRefresh(devRefreshMac);
+    herald::ble::BLEDevice& devRefreshPtr = db.device(devRefresh);
+    devices = db.matches([](auto& deviceRef) {
+      return true;
+    });
+    std::cout << "Devices:-" << std::endl;
+    for (auto& d : devices) {
+      std::cout << "Mac: " << d.get().identifier() 
+                << ", Payload: " << (d.get().payloadData().has_value() ? d.get().payloadData().value().hexEncodedString() : "Empty") << std::endl;
+    }
+    REQUIRE(db.size() == 3);
+    REQUIRE(delegate.createCallbackCalled == true);
+    REQUIRE(delegate.updateCallbackCalled == true);
+    REQUIRE(delegate.deleteCallbackCalled == false);
+    REQUIRE(delegate.dev.has_value());
+    REQUIRE(delegate.dev.value().get() == devRefreshPtr);
+
+    // now fetch its payload - should reduce the total number of devices
+    herald::data::PayloadData devRefreshPayload(std::byte(0x55),24); // same as before
+    devRefreshPtr.payloadData(devRefreshPayload);
+    devices = db.matches([](auto& deviceRef) {
+      return true;
+    });
+    std::cout << "Devices:-" << std::endl;
+    for (auto& d : devices) {
+      std::cout << "Mac: " << d.get().identifier() 
+                << ", Payload: " << (d.get().payloadData().has_value() ? d.get().payloadData().value().hexEncodedString() : "Empty") << std::endl;
+    }
+    REQUIRE(db.size() == 2); // original targetID with this payload should have been deleted
+    REQUIRE(delegate.createCallbackCalled == true);
+    REQUIRE(delegate.updateCallbackCalled == true);
+    REQUIRE(delegate.deleteCallbackCalled == true);
+    REQUIRE(delegate.dev.has_value());
+    REQUIRE(delegate.dev.value().get() == devRefreshPtr);
+  }
+}


### PR DESCRIPTION
Fixes #69. Removes BLEDB items with same payload (i.e. old mac addresses) without waiting for the (2 minute) timeout.
Tested on nRF52832DK with iOS client rotating mac address with same payload.
Signed-off-by: Adam Fowler <adam@adamfowler.org>
