### PR TITLE
Fixes #71. Gatt read payload now resilient.

### DIFF
--- a/herald/include/herald/ble/ble_coordinator.h
+++ b/herald/include/herald/ble/ble_coordinator.h
@@ -57,6 +57,12 @@ public:
       HTDBG("Provisioning connections");
     }
 
+    // Don't close connections if we've only paused for advertising/scanning
+    if (iterationsSinceBreak >= breakEvery &&
+      iterationsSinceBreak < (breakEvery + breakFor) ) {
+        return previouslyProvisioned;
+    }
+
     // Remove those previously provisoned that we no longer require
     for (auto& previous : previouslyProvisioned) {
       bool found = false;
@@ -73,6 +79,7 @@ public:
         }
       }
     }
+
     // Now provision new connections
     std::vector<PrioritisedPrerequisite> provisioned;
     // For this provider, a prerequisite is a connection to a remote target identifier over Bluetooth


### PR DESCRIPTION
Issue was caused by gatt read payload
- Added isReading guard on temporary state
- Forces serviceDiscovery to wait both for discovery and readPayload (if applicable)
- readPayload seems to need to finish immediately after service discovery (much like on iOS) - so some state must be relevant within Zephyr RTOS
- May want in future to add more error handling/detection in gatt_read_cb
- Another bug noticed after many discoveries. Likely a memory issue so will log elsewhere.
Signed-off-by: Adam Fowler <adam@adamfowler.org>
