### PR TITLE
Fixes #52. Clears newly allocated payload temporary copy once used.

### DIFF
--- a/herald/src/ble/zephyr/concrete_ble_transmitter.cpp
+++ b/herald/src/ble/zephyr/concrete_ble_transmitter.cpp
@@ -230,8 +230,10 @@ namespace zephyrinternal {
           newvalue[i] = (char)payload->at(i);
         }
         value = newvalue;
-        return bt_gatt_attr_read(conn, attr, buf, len, offset, value,
+        auto res = bt_gatt_attr_read(conn, attr, buf, len, offset, value,
           payload->size());
+        delete newvalue;
+        return res;
       // } else {
       //   value = "venue value"; // TODO replace with the use of PDS
       }


### PR DESCRIPTION
Zephyr requires a char* allocation to copy to its attribute cache. Usage is correct.
We now also clear up the temporary value. I have confirmed Zephyr doesn't do this itself.
Tested on nRF52832DK.
Signed-off-by: Adam Fowler <adam@adamfowler.org>