### PR TITLE
Fixes #80. C++ API v2.0 ready for publishing.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -89,5 +89,8 @@
   },
   "cSpell.words": [
     "backoff"
-  ]
+  ],
+  "cmake.configureSettings": {
+    // "CODE_COVERAGE": "ON"
+  }
 }

--- a/install-deps-ubuntu.sh
+++ b/install-deps-ubuntu.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Run this ONCE
 # Then run the make-all-zephyr.sh file
@@ -34,7 +34,7 @@ export GNUARMEMB_TOOLCHAIN_PATH="~/gnuarmemb/gcc-arm-none-eabi-10-2020-q4-major"
 # Now install Nordic connect - https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/gs_installing.html
 mkdir ~/ncs
 cd ~/ncs
-west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.5.0
+west init -m https://github.com/nrfconnect/sdk-nrf --mr v1.6.1
 west update
 west zephyr-export
 

--- a/make-all-zephyr.sh
+++ b/make-all-zephyr.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ORIG=$PWD
 


### PR DESCRIPTION
C++ API v2.0.0 ready for publishing
- Using bash instead of sh in build scripts
- Added optional (disabled by default) code coverage building
Signed-off-by: Adam Fowler <adam@adamfowler.org>
